### PR TITLE
adding boolean as a data type

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Supported types:
 
     string (input)
     text (textarea)
+    boolean (checkbox)
     color (uses built-in RailsAdmin color picker)
     html (supports Rich, glebtv-ckeditor, ckeditor, but does not require any of them)
     sanitized (requires sanitize -- sanitizes HTML before saving to DB [Warning: uses RELAXED config!])

--- a/app/views/rails_admin/main/_setting_value.html.haml
+++ b/app/views/rails_admin/main/_setting_value.html.haml
@@ -1,5 +1,7 @@
 - if ['string', 'integer', 'phone', 'email', 'address', 'url', 'domain'].include?(@object.type)
   = form.text_field :raw, :value => field.value
+- if @object.type == 'boolean'
+  = form.check_box :raw, {:value => field.value}, 'true', 'false'
 - if @object.type == 'color'
   = form.text_field :raw, :value => field.value, 'data-color' => true, style: "background-color: ##{field.value}"
 - elsif %w(text yaml phones).include?( @object.type )

--- a/lib/rails_admin_settings/processing.rb
+++ b/lib/rails_admin_settings/processing.rb
@@ -7,7 +7,7 @@ module RailsAdminSettings
     end
 
     def text_type?
-      (RailsAdminSettings.types - ['phone', 'phones', 'integer', 'yaml']).include? type
+      (RailsAdminSettings.types - ['phone', 'phones', 'integer', 'yaml', 'boolean']).include? type
     end
 
     def upload_type?
@@ -16,6 +16,10 @@ module RailsAdminSettings
 
     def html_type?
       ['html', 'sanitized'].include? type
+    end
+
+    def boolean_type?
+      type == 'boolean'
     end
 
     def value
@@ -65,6 +69,8 @@ module RailsAdminSettings
         ''
       elsif integer_type?
         0
+      elsif boolean_type?
+        false
       elsif yaml_type?
         nil
       elsif phone_type?
@@ -81,6 +87,8 @@ module RailsAdminSettings
     def default_serializable_value
       if phones_type?
         ''
+      elsif boolean_type?
+        'false'
       else
         default_value
       end
@@ -123,6 +131,8 @@ module RailsAdminSettings
         process_text
       elsif integer_type?
         raw.to_i
+      elsif boolean_type?
+        raw == 'true'
       elsif yaml_type?
         load_yaml
       elsif phone_type?

--- a/lib/rails_admin_settings/types.rb
+++ b/lib/rails_admin_settings/types.rb
@@ -3,6 +3,7 @@ module RailsAdminSettings
     [
       'string',
       'integer',
+      'boolean',
       'html',
       'sanitized',
       'yaml',

--- a/spec/defaults_spec.rb
+++ b/spec/defaults_spec.rb
@@ -47,6 +47,8 @@ describe 'Settings loading defaults' do
     Settings.ns_default = 'other'
     Settings.ns_fallback = 'other'
     Settings.ns(:main).phone.should eq '906 1111111'
+    Settings.ns(:main).true_setting.should be_true
+    Settings.ns(:main).false_setting.should be_false
     Settings.ns(:other).footer.should eq 'zzz'
     Settings.ns(:main).footer.should eq 'test <b></b>'
     Settings.footer.should eq 'zzz'

--- a/spec/support/defaults.yml
+++ b/spec/support/defaults.yml
@@ -6,6 +6,14 @@ main:
   phone:
     type: 'phone'
     value: '906 1111111'
+
+  true_setting:
+    type: 'boolean'
+    value: true
+
+  false_setting:
+    type: 'boolean'
+    value: false
   
   disabled:
     enabled: false

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -3,6 +3,15 @@
 require 'spec_helper'
 
 describe 'Settings types' do
+  it 'boolean' do
+    Settings.get(:testbool, type: 'boolean').value.should be_false
+    Settings.get(:testbool, default: true, type: 'boolean').value.should be_false
+    Settings.get(:testbool2, default: true, type: 'boolean').value.should be_true
+    Settings.testbool2.should be_true
+    Settings.set(:testbool3, true, type: 'boolean')
+    Settings.testbool3.should be_true
+  end
+
   it 'html' do
     Settings.get(:email, type: 'html', default: 'test@example.com').to_s.should eq 'test@example.com'
   end


### PR DESCRIPTION
adding a 'boolean' data type that can be edited with a check box.

I made boolean value to be either 'true' or 'false', since the raw field is typecast as a String.

I've tried to remove the String typecast before from the raw field, but it resulted in so many conflicts with Integer and YAML types that I decided to just use 'true' and 'false' for boolean values and leave the typecast on raw field as is.