### PR TITLE
Fixed Paperclip installation checking

### DIFF
--- a/lib/rails_admin_settings/uploads.rb
+++ b/lib/rails_admin_settings/uploads.rb
@@ -25,7 +25,7 @@ module RailsAdminSettings
 
         Settings.file_uploads_supported = true
         Settings.file_uploads_engine = :paperclip
-      elsif RailsAdminSettings.active_record? && defined?('Paperclip')
+      elsif RailsAdminSettings.active_record? && defined?(Paperclip)
         if defined?(Rails)
           base.has_attached_file(:file)
         else


### PR DESCRIPTION
Fixes issue #5 where including `rails_admin_settings` gem brakes rails when there has no `paperclip` gem included into Rails Gemfile:

```
`method_missing': undefined method `has_attached_file' for #<Class
rails_admin_settings-1.0.1/lib/rails_admin_settings/uploads.rb:30:in `included'
```